### PR TITLE
Use additionally shift for translation and ctrl for rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,11 @@ Features
 - Catalog of existing LEGO® parts
 - Customize measurements to get a perfect fit
 - Create a sharable link of your part
+
+# Running the local version
+
+You need to have [TypeScript](https://www.typescriptlang.org/) installed. In the project root, run `tsc`. This should run without errors and create the file `app.js`.
+
+Now you need a webserver that locally serves the files from the project directory. If you have python installed, you can call `python3 -m http.server`.It will tell you the port, for example 8000 and you can visit http://localhost:8000 in your browser. Alternatively, you can install [http-server](https://www.npmjs.com/package/http-server), which will also create a server in port 8000.
+
+If you work on the code, run `tsc --watch`, which will recompile everytime you change a source file.

--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -204,13 +204,13 @@ class Editor {
 
 	private onMouseDown(event: MouseEvent) {
 		const {ctrlKey, shiftKey} = event;
-		if(event.button === 0 && !ctrlKey && !shiftKey) {
+		if (event.button === 0 && !ctrlKey && !shiftKey) {
 			if (this.handles.onMouseDown(event)) {
 				this.mouseMode = MouseMode.Left;
 			}
-		} else if(event.button === 1 || shiftKey) {
+		} else if (event.button === 1 || shiftKey) {
 			this.mouseMode = MouseMode.Middle;
-		} else if(event.button === 2 || ctrlKey) {
+		} else if (event.button === 2 || ctrlKey) {
 			this.mouseMode = MouseMode.Right;
 		}
 		event.preventDefault();

--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -203,14 +203,15 @@ class Editor {
 	}
 
 	private onMouseDown(event: MouseEvent) {
-		switch(event.button) {
-			case 0: 
-				if (this.handles.onMouseDown(event)) {
-					this.mouseMode = MouseMode.Left;
-				}
-				break;
-			case 1: this.mouseMode = MouseMode.Middle; break;
-			case 2: this.mouseMode = MouseMode.Right; break;
+		const {ctrlKey, shiftKey} = event;
+		if(event.button === 0 && !ctrlKey && !shiftKey) {
+			if (this.handles.onMouseDown(event)) {
+				this.mouseMode = MouseMode.Left;
+			}
+		} else if(event.button === 1 || shiftKey) {
+			this.mouseMode = MouseMode.Middle;
+		} else if(event.button === 2 || ctrlKey) {
+			this.mouseMode = MouseMode.Right;
 		}
 		event.preventDefault();
 	}

--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -208,9 +208,9 @@ class Editor {
 			if (this.handles.onMouseDown(event)) {
 				this.mouseMode = MouseMode.Left;
 			}
-		} else if(event.button === 1 || shiftKey) {
+		} else if (event.button === 1 || shiftKey) {
 			this.mouseMode = MouseMode.Middle;
-		} else if(event.button === 2 || ctrlKey) {
+		} else if (event.button === 2 || ctrlKey) {
 			this.mouseMode = MouseMode.Right;
 		}
 		event.preventDefault();


### PR DESCRIPTION
This PR affects the function `onMouseDown` in the `Editor.ts` file: it adds in addition to the mouse controls the possibility of using the shift key for translation and the ctrl key for rotation (useful for using partdesigner in laptops with left click only). The modification is as follows:

```
 private onMouseDown(event: MouseEvent) {
	const {ctrlKey, shiftKey} = event;
	if(event.button === 0 && !ctrlKey && !shiftKey) {
		if (this.handles.onMouseDown(event)) {
			this.mouseMode = MouseMode.Left;
		}
	} else if(event.button === 1 || shiftKey) {
		this.mouseMode = MouseMode.Middle;
	} else if(event.button === 2 || ctrlKey) {
		this.mouseMode = MouseMode.Right;
	}
	event.preventDefault();
}
```