### PR TITLE
Upgrade to latest typescript (5.3.3)

### DIFF
--- a/src/editor/Editor.ts
+++ b/src/editor/Editor.ts
@@ -248,7 +248,7 @@ class Editor {
 		}
 	}
 
-	private onScroll(event: MouseWheelEvent) {
+	private onScroll(event: WheelEvent) {
 		this.zoom *= event.deltaY < 0 ? this.zoomStep : 1 / this.zoomStep;
 		this.camera.size = this.zoom;
 		this.camera.render();


### PR DESCRIPTION
Changes the name of type MouseWheelEvent to WheelEvent


Before
```
> tsc 
src/editor/Editor.ts:251:26 - error TS2552: Cannot find name 'MouseWheelEvent'. Did you mean 'MouseEvent'?

251  private onScroll(event: MouseWheelEvent) {
                             ~~~~~~~~~~~~~~~

  ../../.asdf/installs/nodejs/19.7.0/lib/node_modules/typescript/lib/lib.dom.d.ts:15636:13
    15636 declare var MouseEvent: {
                      ~~~~~~~~~~
    'MouseEvent' is declared here.


Found 1 error in src/editor/Editor.ts:251
```

After
```
> tsc

```
